### PR TITLE
DWIM on `use Class::Tiny "foo"; use Class::Tiny "bar"`

### DIFF
--- a/lib/Class/Tiny.pm
+++ b/lib/Class/Tiny.pm
@@ -27,12 +27,11 @@ sub import {
         defined and !ref and /^[^\W\d]\w*$/s
           or Carp::croak "Invalid accessor name '$_'"
     } @_;
-    $CLASS_ATTRIBUTES{$pkg} = { map { $_ => undef } @attr };
-    my $child = !!@{"${pkg}::ISA"};
+    $CLASS_ATTRIBUTES{$pkg}{$_} = undef for @attr;
+    @{"${pkg}::ISA"} = $class unless @{"${pkg}::ISA"};
     #<<< No perltidy
     eval join "\n", ## no critic: intentionally eval'ing subs here
       "package $pkg;",
-      ( $child ? () : "\@${pkg}::ISA = 'Class::Tiny';" ),
       map {
         "sub $_ { return \@_ == 1 ? \$_[0]->{$_} : (\$_[0]->{$_} = \$_[1]) }\n"
       } grep { ! *{"$pkg\::$_"}{CODE} } @attr;

--- a/t/foxtrot.t
+++ b/t/foxtrot.t
@@ -1,0 +1,19 @@
+use 5.008001;
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::More 0.96;
+use TestUtils;
+
+require_ok("Foxtrot");
+
+subtest "attribute set as list" => sub {
+    my $obj = new_ok( "Foxtrot", [ foo => 42, bar => 23 ] );
+    is( $obj->foo, 42, "foo is set" );
+    is( $obj->bar, 23, "bar is set" );
+};
+
+done_testing;
+# COPYRIGHT
+# vim: ts=4 sts=4 sw=4 et:

--- a/t/lib/Foxtrot.pm
+++ b/t/lib/Foxtrot.pm
@@ -1,0 +1,10 @@
+use 5.008001;
+use strict;
+use warnings;
+
+package Foxtrot;
+
+use Class::Tiny 'foo';
+use Class::Tiny 'bar';
+
+1;


### PR DESCRIPTION
This small patch allows the following to work:

```
package Foxtrot;
use Class::Tiny qw( foo );
use Class::Tiny qw( bar );
```

It's not documented because people probably ought not to do it; but if they do do it, it would be nice if it worked.
