### PR TITLE
Silence "used only once" warnings for BUILD and DEMOLISH

### DIFF
--- a/lib/Class/Tiny.pm
+++ b/lib/Class/Tiny.pm
@@ -89,6 +89,7 @@ my $_PRECACHE = sub {
       ? [$class]
       : mro::get_linear_isa($class);
     for my $s ( @{ $LINEAR_ISA_CACHE{$class} } ) {
+        no warnings 'once';
         $BUILD_CACHE{$s}    = *{"$s\::BUILD"}{CODE};
         $DEMOLISH_CACHE{$s} = *{"$s\::DEMOLISH"}{CODE};
     }


### PR DESCRIPTION
Commit 030fbc23 made Class::Tiny start warning about Devel::PartialDump::BUILD and ::DEMOLISH only being mentioned once, breaking downstream tests for expected warnings.
