### PR TITLE
Support for Class::XSAccessor accessors

### DIFF
--- a/lib/Class/Tiny.pm
+++ b/lib/Class/Tiny.pm
@@ -15,6 +15,8 @@ require( $] >= 5.010 ? "mro.pm" : "MRO/Compat.pm" ); ## no critic:
 
 my %CLASS_ATTRIBUTES;
 
+my $HAS_XS = eval { require Class::XSAccessor; 1 };
+
 sub import {
     my $class = shift;
     my $pkg   = caller;
@@ -82,6 +84,11 @@ sub $name {
         : ( \$_[0]{$name} = ( \@_ == 2 ) ? \$_[1] : \$default )
     );
 }
+HERE
+    }
+    elsif ($HAS_XS) {
+        return << "HERE";
+    use Class::XSAccessor accessors => [ $name => ];
 HERE
     }
     else {


### PR DESCRIPTION
This six line addition roughly doubles the speed of any accessors that don't have a default by building them with Class::XSAccessor. It has a negligible effect on start up time and memory usage. When Class::XSAccessor is not installed, it has no effect. No extra test cases are provided because the intention is for this to have no detectable effect other than the speed-up.

Possible additional changes: adding Class::XSAccessor as a `suggests` dependency.